### PR TITLE
Fixé : [nodemon] starting `node app.js`💪

### DIFF
--- a/backend/middleware/authenticateToken.js
+++ b/backend/middleware/authenticateToken.js
@@ -18,3 +18,4 @@ const authenticateJWT = (req, res, next) => {
         res.sendStatus(401);
     }
 };
+module.exports = { authenticateJWT };


### PR DESCRIPTION
module.exports = { authenticateJWT }; oublié dans authenticateToken.js